### PR TITLE
Add support to all versions of cvss

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 extend-ignore = E231
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 10
+max-line-length = 120

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,26 @@ def fetch_data(cve_id:str) -> dict:
         return {}
 
 
+def get_cvss_score_from_cve_org(data:dict):
+    level = level_name = None
+    version = 0
+    try:
+        metrics = data['containers']['cna']['metrics']
+        for metric in metrics:
+            for key, val in metric.items():
+                if ('cvss' in key and isinstance(val, dict) and 'baseScore' in val.keys()):
+                    v = float(val['version'])
+                    if (v > version):
+                        level = val['baseScore']
+                        level_name = val['baseSeverity']
+                        version = v
+    except (ValueError, TypeError, KeyError):
+        # Error is expected in case 'metrics' is not in response
+        pass
+    finally:
+        return (level, level_name)
+
+
 def build_svg(id:str, level:str, level_name:str) -> str:
     logo = "app/bug.svg"
     link = CVE_REDIRECT_LINK + id
@@ -64,12 +84,6 @@ async def cve_badge(
         id=Annotated[int, Path(title=ID_DOC, gt=1, le=99999999)]):
     cve_id = f'{year}-{id:04}'
     data_json = fetch_data(cve_id)
-    try:
-        metrics = data_json['containers']['cna']['metrics'][0]['cvssV3_1']
-        level = metrics['baseScore']
-        level_name = metrics['baseSeverity']
-    except Exception:
-        level = None
-        level_name = None
+    level, level_name = get_cvss_score_from_cve_org(data_json)
     image = build_svg(cve_id, level, level_name)
     return Response(image, media_type="image/svg+xml")

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -39,13 +39,6 @@ def test_valid_cve_MEDIUM53_CVSS_3_1():
     assert "5.3" in response.text
 
 
-def test_valid_cve_MEDIUM68_CVSS_3_1():
-    response = client.get("/CVE-2023-0795")
-    assert response.status_code == 200
-    assert "MEDIUM" in response.text
-    assert "6.8" in response.text
-
-
 def test_valid_cve_CRITICAL98_CVSS_3_1():
     response = client.get("/CVE-2023-0750")
     assert response.status_code == 200
@@ -59,3 +52,11 @@ def test_valid_cve_LOW35_CVSS_3_1_and_less():
     assert response.status_code == 200
     assert "LOW" in response.text
     assert "3.2" in response.text
+
+
+def test_valid_cve_CRITICAL96_CVSS3_0():
+    '''This test checks that cvss v3.0 is working'''
+    response = client.get('/CVE-2022-0153')
+    assert response.status_code == 200
+    assert "CRITICAL" in response.text
+    assert "9.6" in response.text


### PR DESCRIPTION
Fixes #1 :
- [x] Supports all versions from CVE.org
- [x] Return the highest CVSS Version score/severity if several versions are available
 