### PR TITLE
Fix alignment not allowed in string format specifier

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -82,6 +82,7 @@ def build_svg(id:str, level:str, level_name:str) -> str:
 async def cve_badge(
         year=Annotated[int, Path(title=YEAR_DOC, gt=1900, le=2100)],
         id=Annotated[int, Path(title=ID_DOC, gt=1, le=99999999)]):
+    year, id = int(year), int(id)
     cve_id = f'{year}-{id:04}'
     data_json = fetch_data(cve_id)
     level, level_name = get_cvss_score_from_cve_org(data_json)


### PR DESCRIPTION
Fix the following error :
```log
 File "cve-badge.li/app/main.py", line 85, in cve_badge
    cve_id=f'{year}-{id:04}'
ValueError: '=' alignment not allowed in string format specifier
```
Seems related to the python version.