### PR TITLE
Add  Support for NIST CVSS Score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 __*__
 *~
+app/.env

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,4 @@
-import json
 import os
-import traceback
 
 from functools import lru_cache
 from typing import Annotated
@@ -41,11 +39,10 @@ def fetch_data_from_cve_org(cve_id:str) -> dict:
     try:
         response = requests.get(url, timeout=REQUESTS_TIMEOUT_SECONDS)
         return response.json()
-    except Exception as e:
-        print(e)
-        print(url)
+    except Exception:
         return {}
-    
+
+
 @lru_cache
 def fetch_data_from_nist(cve_id:str) -> dict:
     ''' Fetch fata from NIST API '''
@@ -57,7 +54,7 @@ def fetch_data_from_nist(cve_id:str) -> dict:
         response = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT_SECONDS)
         response.raise_for_status()
         return response.json()
-    except Exception as e:
+    except Exception:
         return {}
 
 
@@ -78,11 +75,12 @@ def get_cvss_score_from_nist(cve_id:str):
                         level = data['baseScore']
                         level_name = data['baseSeverity']
                         version = v
-    except (ValueError, TypeError, KeyError) as e:
+    except (ValueError, TypeError, KeyError):
         # Error is expected in case 'metrics' is not in response
         pass
     finally:
         return (level, level_name)
+
 
 def get_cvss_score_from_cve_org(cve_id:str):
     data = fetch_data_from_cve_org(cve_id)
@@ -104,11 +102,13 @@ def get_cvss_score_from_cve_org(cve_id:str):
     finally:
         return (level, level_name)
 
+
 def get_cvss_score(cve_id:str):
     values = get_cvss_score_from_cve_org(cve_id)
     if (None in values):
         values = get_cvss_score_from_nist(cve_id)
     return values
+
 
 def build_svg(id:str, level:str, level_name:str) -> str:
     logo = "app/bug.svg"

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,25 @@
 import json
+import os
+import traceback
+
 from functools import lru_cache
 from typing import Annotated
-from urllib.request import urlopen
+import requests
 
 from fastapi import FastAPI, Path
 from fastapi.responses import HTMLResponse, Response
 from pybadges import badge
 
 # CONSTANTS
-CVE_API_ENDPOINT = 'https://cveawg.mitre.org/api/cve/'
+MIRTRE_API_ENDPOINT = 'https://cveawg.mitre.org/api/cve/'
+NIST_API_ENDPOINT = 'https://services.nvd.nist.gov/rest/json/cves/2.0'
+NIST_DISCLAIMER = 'This product uses the NVD API but is not endorsed or certified by the NVD.'
 CVE_REDIRECT_LINK = 'https://cve.mitre.org/cgi-bin/cvename.cgi?name='
 DEFAULT_VALUE = '?'
 DEFAULT_COLOR = '#888'
 YEAR_DOC = "The year of publication of the CVE"
 ID_DOC = "The ID of the CVE"
+REQUESTS_TIMEOUT_SECONDS = 7
 
 # INIT APP
 app = FastAPI()
@@ -30,16 +36,56 @@ def rgb_to_hex(r:int, g:int, b:int) -> str:
 
 
 @lru_cache
-def fetch_data(cve_id:str) -> dict:
-    url = CVE_API_ENDPOINT + f"CVE-{cve_id}"
+def fetch_data_from_cve_org(cve_id:str) -> dict:
+    url = MIRTRE_API_ENDPOINT + f"CVE-{cve_id}"
     try:
-        response = urlopen(url, timeout=5)
-        return json.loads(response.read())
-    except Exception:
+        response = requests.get(url, timeout=REQUESTS_TIMEOUT_SECONDS)
+        return response.json()
+    except Exception as e:
+        print(e)
+        print(url)
+        return {}
+    
+@lru_cache
+def fetch_data_from_nist(cve_id:str) -> dict:
+    ''' Fetch fata from NIST API '''
+    api_key = os.getenv('NIST_API_KEY')
+    try:
+        url = NIST_API_ENDPOINT
+        params = {'cveId': 'CVE-'+cve_id}
+        headers = {'apiKey': api_key}
+        response = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
         return {}
 
 
-def get_cvss_score_from_cve_org(data:dict):
+def get_cvss_score_from_nist(cve_id:str):
+    data = fetch_data_from_nist(cve_id)
+    level = level_name = None
+    version = 0
+    try:
+        metrics = data['vulnerabilities'][0]['cve']['metrics']
+        for _, metric_list in metrics.items():
+            for metric in metric_list:
+                if metric['type'] != 'Primary':
+                    continue
+                data = metric['cvssData']
+                if (isinstance(data, dict) and 'baseScore' in data.keys()):
+                    v = float(data['version'])
+                    if (v > version):
+                        level = data['baseScore']
+                        level_name = data['baseSeverity']
+                        version = v
+    except (ValueError, TypeError, KeyError) as e:
+        # Error is expected in case 'metrics' is not in response
+        pass
+    finally:
+        return (level, level_name)
+
+def get_cvss_score_from_cve_org(cve_id:str):
+    data = fetch_data_from_cve_org(cve_id)
     level = level_name = None
     version = 0
     try:
@@ -58,6 +104,11 @@ def get_cvss_score_from_cve_org(data:dict):
     finally:
         return (level, level_name)
 
+def get_cvss_score(cve_id:str):
+    values = get_cvss_score_from_cve_org(cve_id)
+    if (None in values):
+        values = get_cvss_score_from_nist(cve_id)
+    return values
 
 def build_svg(id:str, level:str, level_name:str) -> str:
     logo = "app/bug.svg"
@@ -84,7 +135,6 @@ async def cve_badge(
         id=Annotated[int, Path(title=ID_DOC, gt=1, le=99999999)]):
     year, id = int(year), int(id)
     cve_id = f'{year}-{id:04}'
-    data_json = fetch_data(cve_id)
-    level, level_name = get_cvss_score_from_cve_org(data_json)
-    image = build_svg(cve_id, level, level_name)
+    score, label = get_cvss_score(cve_id)
+    image = build_svg(cve_id, score, label)
     return Response(image, media_type="image/svg+xml")

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -60,3 +60,17 @@ def test_valid_cve_CRITICAL96_CVSS3_0():
     assert response.status_code == 200
     assert "CRITICAL" in response.text
     assert "9.6" in response.text
+
+def test_valid_cve_NIST_only_1():
+    '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''
+    response = client.get('/CVE-2023-27603')
+    assert response.status_code == 200
+    assert "CRITICAL" in response.text
+    assert "9.8" in response.text
+
+def test_valid_cve_NIST_only_2():
+    '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''
+    response = client.get('/CVE-2023-0399')
+    assert response.status_code == 200
+    assert "MEDIUM" in response.text
+    assert "5.4" in response.text

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -61,12 +61,14 @@ def test_valid_cve_CRITICAL96_CVSS3_0():
     assert "CRITICAL" in response.text
     assert "9.6" in response.text
 
+
 def test_valid_cve_NIST_only_1():
     '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''
     response = client.get('/CVE-2023-27603')
     assert response.status_code == 200
     assert "CRITICAL" in response.text
     assert "9.8" in response.text
+
 
 def test_valid_cve_NIST_only_2():
     '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -63,7 +63,7 @@ def test_valid_cve_CRITICAL96_CVSS3_0():
 
 
 def test_valid_cve_NIST_only_1():
-    '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''
+    '''Checks that CVSS score not listed in CVE.org  is retrieved from NIST'''
     response = client.get('/CVE-2023-27603')
     assert response.status_code == 200
     assert "CRITICAL" in response.text
@@ -71,7 +71,7 @@ def test_valid_cve_NIST_only_1():
 
 
 def test_valid_cve_NIST_only_2():
-    '''This test checks that CVS that are not listed in CVE.org but in NIST are retrieved'''
+    '''Checks that CVSS score not listed in CVE.org is retrieved from NIST'''
     response = client.get('/CVE-2023-0399')
     assert response.status_code == 200
     assert "MEDIUM" in response.text


### PR DESCRIPTION
Uses `NIST` API to retrieve CVSS score when not available on `cve.org`
Improve support for CVEs without a score assigned on cve.org.
Rate Limit of API requests is:
 - 5 req/30 seconds without API Key
 - 50 req/30 seconds with an API Key

closes #2 